### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://logicpixel.visualstudio.com/0ae40109-a136-4389-b477-585dd1500e73/31078c3a-2d18-400a-b02f-3bc574fcefe7/_apis/work/boardbadge/4297b20e-f158-4170-8257-38dceda45753)](https://logicpixel.visualstudio.com/0ae40109-a136-4389-b477-585dd1500e73/_boards/board/t/31078c3a-2d18-400a-b02f-3bc574fcefe7/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://logicpixel.visualstudio.com/0ae40109-a136-4389-b477-585dd1500e73/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.